### PR TITLE
Change colour scheme to fit NUS colour schema and change UI details

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -96,24 +96,23 @@
 .list-cell {
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap : 0;
-    -fx-padding: 0 0 0 0;
+    -fx-padding: 4 0;
+    -fx-background-insets: 4 0;
 }
 
-.list-cell:filled:even {
-    -fx-background-color: #3c3e3f;
-}
-
+.list-cell:filled:even,
 .list-cell:filled:odd {
-    -fx-background-color: #515658;
+    -fx-background-color: transparent;
 }
 
 .list-cell:filled:selected {
     -fx-background-color: #424d5f;
+    -fx-background-radius: 15;
+    -fx-padding: 8 0 8 24;
 }
 
 .list-cell:filled:selected #cardPane {
     -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
 }
 
 .list-cell .label {
@@ -308,8 +307,12 @@
 }
 
 #cardPane {
-    -fx-background-color: transparent;
+    -fx-background-color: #656768a6;
     -fx-border-width: 0;
+    -fx-background-radius: 15;
+    -fx-background-insets: 4 8;
+    -fx-border-radius: 10;
+    -fx-padding: 12 16;
 }
 
 #commandTypeLabel {
@@ -344,10 +347,10 @@
 
 #tags .label {
     -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
+    -fx-background-color: #a9a9a9;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
-    -fx-background-radius: 2;
+    -fx-background-radius: 999;
     -fx-font-size: 11;
 }
 
@@ -358,10 +361,10 @@
 
 #modules .label {
     -fx-text-fill: white;
-    -fx-background-color: #0d9a09;
+    -fx-background-color: #EF7C00;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
-    -fx-background-radius: 2;
+    -fx-background-radius: 999;
     -fx-font-size: 11;
 }
 
@@ -372,10 +375,10 @@
 
 #faculties .label {
     -fx-text-fill: white;
-    -fx-background-color: #be5768;
+    -fx-background-color: #003D7C;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
-    -fx-background-radius: 2;
+    -fx-background-radius: 999;
     -fx-font-size: 11;
 }
 
@@ -386,8 +389,8 @@
 }
 
 #cardPane.favorite-card {
-    -fx-background-color: #5a5348 !important;
-    -fx-background-radius: 5;
+    -fx-background-color: rgba(239, 124, 0, 0.25) !important;
+    -fx-background-radius: 15;
 }
 
 #cardPane.favorite-card .favorite_star {


### PR DESCRIPTION
Summary:
This PR refines the person list (left pane) to improve readability and aesthetics. It removes the old alternating row colors, introduces rounded contact cards with spacing, and applies NUS-themed accents (orange/blue) while keeping the selected state clearly highlighted.

- Removed alternating row colors
- Added spacing between contacts
- Rounded, padded contact cards
- Favorite vs normal contact styling
- Normal contacts: subtle translucent base (#656768a6).
- Favorite contacts: translucent NUS orange background (rgba(239, 124, 0, 0.25))
- Clear selected state (kept light blue), selected pane is shifted to the right
- Chip colors aligned to NUS accents
- #modules .label → orange #EF7C00
- #faculties .label → blue #003D7C
- #tags .label → neutral gray (subtle) #a9a9a9
- All chips now use -fx-background-radius: 999 for pill shape.

Testing
- Favorites render with the orange-tinted card; non-favorites use the subtle base.
- Selected contact remains clearly highlighted in blue and works with rounded corners.
- Long names/addresses still render cleanly with added internal padding.
- Spacing between cards persists across scroll, selection, and filtering.
<img width="1917" height="1013" alt="image" src="https://github.com/user-attachments/assets/e8913255-56d1-4585-a455-6ceb81090980" />

Notes

- This PR focuses on the left pane visual improvements only.
- Right-side Contact Details panel retains the AB3 dark theme; accents for chips are now consistent with NUS colors.